### PR TITLE
Add docs for test tool setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,15 @@ It offers two flavours:
 2. **Python with Rust** – includes a PyO3 extension.
 
 Run `copier copy` and answer the prompts to generate a project.
+
+## Running Tests
+
+The test suite relies on the `pytest-copier` plugin and uses `ruff` and `pyright`
+for linting and type checking. Ensure these tools are installed before running
+`pytest`:
+
+```bash
+pip install pytest-copier ruff pyright
+```
+
+You can also run `scripts/setup_test_deps.sh` to install them automatically.

--- a/scripts/setup_test_deps.sh
+++ b/scripts/setup_test_deps.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Install tools needed to run tests for this template.
+# These include the pytest-copier plugin and tooling for linting and type checking.
+set -euo pipefail
+
+pip install pytest-copier ruff pyright


### PR DESCRIPTION
## Summary
- document needed dev tools in README
- provide script to install pytest-copier, ruff and pyright

## Testing
- `bash scripts/setup_test_deps.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pure_pkg')*

------
https://chatgpt.com/codex/tasks/task_e_6848f847aaec8322a09f64303c664b5a

## Summary by Sourcery

Document test tooling requirements and provide an automated script to install them.

Enhancements:
- Add a setup script to automate installation of pytest-copier, ruff, and pyright

Documentation:
- Add a "Running Tests" section to README with instructions for installing test dependencies