### PR TITLE
Fix maturin editable install paths

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -29,6 +29,7 @@ build-backend = "maturin"
 manifest-path = "rust_extension/Cargo.toml"
 python-source = "rust_pkg"
 module-name = "rust_pkg._rust_pkg_rs"
+python-packages = ["{{ package_name }}"]
 {% else %}
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -11,6 +11,15 @@ from pytest_copier.plugin import CopierFixture, CopierProject
 def build_package(project: CopierProject) -> None:
     """Install the generated package in editable mode."""
     project.run(f"{sys.executable} -m pip install -e .")
+    project.run(
+        f"{sys.executable} - <<'PY'\n"
+        "import importlib, site, pathlib\n"
+        "sp = site.getsitepackages()[0]\n"
+        "for p in pathlib.Path(sp).glob('*.pth'):\n"
+        "    site.addsitedir(str(pathlib.Path(p.read_text().strip()).parent))\n"
+        "importlib.invalidate_caches()\n"
+        "PY"
+    )
 
 
 def check_static(project: CopierProject) -> None:


### PR DESCRIPTION
## Summary
- update maturin config to include python package
- reload new paths after installation in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848f84839388322967362ecf87004be