### PR TITLE
Fix Rust package templating

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -27,8 +27,8 @@ requires = ["maturin>=1.5"]
 build-backend = "maturin"
 [tool.maturin]
 manifest-path = "rust_extension/Cargo.toml"
-python-source = "rust_pkg"
-module-name = "rust_pkg._rust_pkg_rs"
+python-source = "{{ package_name }}"
+module-name = "{{ package_name }}._{{ package_name }}_rs"
 python-packages = ["{{ package_name }}"]
 {% else %}
 [build-system]

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -64,3 +64,22 @@ def test_rust_template(copier: CopierFixture, tmp_path: Path) -> None:
 
     pkg = import_package("rust_pkg")
     assert pkg.hello() == "hello from Rust"
+
+
+def test_rust_template_custom_package(copier: CopierFixture, tmp_path: Path) -> None:
+    """Ensure templating uses the provided package name."""
+    proj = copier.copy(
+        tmp_path / "rust_custom",
+        project_name="RustProj",
+        package_name="custom_pkg",
+        use_rust=True,
+    )
+    build_package(proj)
+    check_static(proj)
+
+    assert (proj / "rust_extension").exists()
+    text = (proj / "pyproject.toml").read_text()
+    assert "custom_pkg" in text
+
+    pkg = import_package("custom_pkg")
+    assert pkg.hello() == "hello from Rust"


### PR DESCRIPTION
## Summary
- ensure maturin uses package_name for python-source and module-name
- test rendering Rust variant with custom package name

## Testing
- `pyright`
- `ruff check tests/test_template.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68498ab7826c83229d016615c73d3f07

## Summary by Sourcery

Fix Rust package templating to use the provided package_name in pyproject.toml and add a test for custom package names

Bug Fixes:
- Ensure maturin’s python-source and module-name fields use the configured package_name

Tests:
- Add a test case to verify Rust template rendering with a custom package name