### PR TITLE
Templatize CI workflow

### DIFF
--- a/template/.github/workflows/ci.yml.jinja
+++ b/template/.github/workflows/ci.yml.jinja
@@ -9,8 +9,8 @@ jobs:
   lint-test:
     runs-on: ubuntu-latest
     env:
-      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
+      CS_ACCESS_TOKEN: ${{ "{{" }} secrets.CS_ACCESS_TOKEN {{ "}}" }}
+      CODESCENE_CLI_SHA256: ${{ "{{" }} vars.CODESCENE_CLI_SHA256 {{ "}}" }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -47,11 +47,11 @@ jobs:
         run: |
           uv pip install slipcover pytest-forked
           uv run python -m slipcover \
-            --source=./falcon_pachinko \
+            --source=./{{ package_name }} \
             --omit="*/unittests/*,*/.venv/*" \
             --branch \
             --out coverage.xml \
-            -m pytest --forked -v falcon_pachinko/unittests
+            -m pytest --forked -v {{ package_name }}/unittests
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- convert `ci.yml` to a Jinja template
- parametrize coverage paths using `package_name`

## Testing
- `bash scripts/setup_test_deps.sh`
- `pytest -q` *(fails: RuntimeError from ruff and maturin build)*

------
https://chatgpt.com/codex/tasks/task_e_686c4f6e21cc8322bcff224232e0d327

## Summary by Sourcery

Templatize the GitHub Actions CI workflow by converting `ci.yml` into a Jinja template and parameterizing coverage and test paths using a `package_name` variable.

CI:
- Convert `ci.yml` to a Jinja template for dynamic rendering
- Parameterize coverage source and test invocation paths with `package_name`
- Escape GitHub Actions secrets and vars syntax within the Jinja template