### PR TITLE
Bump shared-actions pins to 18bed1ca

### DIFF
--- a/.github/workflows/act-validation.yml
+++ b/.github/workflows/act-validation.yml
@@ -30,7 +30,7 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Set up Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@3c1fa01bcf4c26dac79975c18b74c01d577dcf95
+        uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           toolchain: stable
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Set up Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@3c1fa01bcf4c26dac79975c18b74c01d577dcf95
+        uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           toolchain: stable
 

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@3c1fa01bcf4c26dac79975c18b74c01d577dcf95
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@18bed1ca49a6de3d8882bd72635a32ae3f023d57
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/template/.github/workflows/act-validation.yml.jinja
+++ b/template/.github/workflows/act-validation.yml.jinja
@@ -31,7 +31,7 @@ jobs:
 
       {% if use_rust %}
       - name: Set up Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@455d9ed03477c0026da96c2541ca26569a74acac
+        uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           toolchain: stable
 

--- a/template/.github/workflows/ci.yml.jinja
+++ b/template/.github/workflows/ci.yml.jinja
@@ -35,7 +35,7 @@ jobs:
 
       {% if use_rust %}
       - name: Set up Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           toolchain: stable
 
@@ -91,7 +91,7 @@ jobs:
       # the work and the CodeScene upload for the same commit.
       - name: Test and Measure Coverage
         if: ${{ "{{" }} github.event_name == 'pull_request' {{ "}}" }}
-        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           output-path: coverage.xml
           format: cobertura

--- a/template/.github/workflows/coverage-main.yml.jinja
+++ b/template/.github/workflows/coverage-main.yml.jinja
@@ -46,13 +46,13 @@ jobs:
 
       {% if use_rust %}
       - name: Set up Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           toolchain: stable
 
       {% endif %}
       - name: Generate coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           output-path: coverage.xml
           format: cobertura
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload coverage data to CodeScene
         if: env.CS_ACCESS_TOKEN != ''
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           format: cobertura
           path: coverage.xml


### PR DESCRIPTION
## Summary

- Advance every `leynos/shared-actions` pin to `18bed1ca49a6de3d8882bd72635a32ae3f023d57` (shared-actions main HEAD), in both this repo's own `.github/workflows/*.yml` and the copier template sources under `template/.github/workflows/*.jinja`, so newly generated projects start at the same pin.
- Picks up the coverage-ratchet baseline-advance fix and the symmetric ±1pp dead-band (shared-actions#353), plus routine follow-ups (#354, #356 whitaker-installer 0.2.6, #344).

## Review walkthrough

- `.github/workflows/{ci,act-validation,dependabot-automerge}.yml`: repo's own CI pins bumped (previously on three different stale SHAs).
- `template/.github/workflows/{ci,act-validation,coverage-main}.yml.jinja`: template source pins bumped, keeping templating syntax intact.
- Left `tests/test_helpers.py` (lines 559/567/724) and `tests/helpers/ci_contracts.py` untouched: these are synthetic fixtures and shape-only regexes for contract tests, not real pins.
- A repo-wide grep confirms no other 40-hex shared-actions SHA remains outside those fixtures.

## Validation

- [x] `make test` — 47 passed, 2 skipped, 3 snapshots passed.
- [ ] CI green on this branch
